### PR TITLE
Http11 default

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -18,14 +18,16 @@ pub async fn do_connection(
 ) -> io::Result<()> {
     let stream = ssl_socket.accept(client_socket).await?;
     let (_, conn) = stream.get_ref();
-    debug!(
-        "ALPN: {:?}",
-        String::from_utf8_lossy(conn.alpn_protocol().unwrap())
-    );
 
     match conn.alpn_protocol() {
-        Some(b"h2") => http2::do_http2(stream, config).await,
-        Some(b"http/1.1") => http11::do_http11(stream, config).await,
+        Some(b"h2") => {
+            debug!("Using 'h2' protocol");
+            http2::do_http2(stream, config).await
+        }
+        Some(b"http/1.1") => {
+            debug!("Using 'http/1.1' protocol");
+            http11::do_http11(stream, config).await
+        }
         Some(protocol) => {
             error!("Bad protocol received: '{:?}' closing connection", protocol);
             Ok(())

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::sync::Arc;
 use tokio::net::TcpStream;
 use tokio_rustls::TlsAcceptor;
-use tracing::{debug, error};
+use tracing::{debug, error, info, trace};
 
 mod http11;
 mod http2;
@@ -31,8 +31,9 @@ pub async fn do_connection(
             Ok(())
         }
         None => {
-            error!("No protocol negociated via APLN! Closing connection");
-            Ok(())
+            info!("No protocol negociated via APLN! Using HTTP/1.1 as default.");
+            trace!("Does the client support it?");
+            http11::do_http11(stream, config).await
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use tracing::{debug, error, info, warn};
 
 mod config;
 mod connection;
-mod http2;
 mod http11;
+mod http2;
 mod method_handlers;
 mod request;
 mod response;


### PR DESCRIPTION
Use HTTP/1.1 when an ALPN negociation failed. This caused a failure with google crawler.